### PR TITLE
Make linter to also lint "tests/" folder, fix linter errors #tooling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
     "env": {
         "browser": true,
         "commonjs": true,
-        "es2021": true
+        "es2021": true,
+        "mocha": true
     },
     "extends": [
         "airbnb-base"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "lint": "eslint --fix src/",
+    "lint": "eslint --fix src/ tests/",
     "test": "nyc mocha tests",
     "start": "node index.js"
   },

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,32 +1,29 @@
-'use strict';
-
 const request = require('supertest');
-
 const sqlite3 = require('sqlite3').verbose();
-const db = new sqlite3.Database(':memory:');
 
+const db = new sqlite3.Database(':memory:');
 const app = require('../src/app')(db);
 const buildSchemas = require('../src/schemas');
 
 describe('API tests', () => {
-    before((done) => {
-        db.serialize((err) => { 
-            if (err) {
-                return done(err);
-            }
+  before((done) => {
+    db.serialize((err) => {
+      if (err) {
+        return done(err);
+      }
 
-            buildSchemas(db);
+      buildSchemas(db);
 
-            done();
-        });
+      done();
     });
+  });
 
-    describe('GET /health', () => {
-        it('should return health', (done) => {
-            request(app)
-                .get('/health')
-                .expect('Content-Type', /text/)
-                .expect(200, done);
-        });
+  describe('GET /health', () => {
+    it('should return health', (done) => {
+      request(app)
+        .get('/health')
+        .expect('Content-Type', /text/)
+        .expect(200, done);
     });
+  });
 });


### PR DESCRIPTION
## Code changes

#### `package.json`, `.eslintrc.json`
Changes in this file are done to make linter also lint the "tests/" folder.
#### `tests/api.test.js`
Changes in this file are done to fix linter errors in the "tests/" folder.

## Tests
No tests are required for this PR.

## Documentation
Make linter also lint "tests/" folder, fix linter errors in "tests/" folder.