### PR TITLE
Enforce tests code coverage checking, create new tests #tooling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,7 @@
     },
     "rules": {
         "consistent-return": "off",
-        "func-names": "off"
+        "func-names": "off",
+        "arrow-body-style": "off"
     }
 }

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,0 +1,8 @@
+{
+    "all": true,
+    "checkCoverage": true,
+    "lines": 80,
+    "branches": 80,
+    "statements": 80,
+    "exclude": ["index.js", "tests"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -782,6 +782,12 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -953,6 +959,20 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "chai": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -974,6 +994,12 @@
           }
         }
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chownr": {
       "version": "1.1.1",
@@ -1196,6 +1222,15 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -2253,6 +2288,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-intrinsic": {
@@ -4015,6 +4056,12 @@
         "pify": "^3.0.0"
       }
     },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -5022,6 +5069,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.20.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "winston": "^3.3.3"
   },
   "devDependencies": {
+    "chai": "^4.3.4",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.24.0",

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,3 +1,4 @@
+const { expect } = require('chai');
 const request = require('supertest');
 const sqlite3 = require('sqlite3').verbose();
 
@@ -18,12 +19,194 @@ describe('API tests', () => {
     });
   });
 
-  describe('GET /health', () => {
-    it('should return health', (done) => {
-      request(app)
-        .get('/health')
-        .expect('Content-Type', /text/)
-        .expect(200, done);
+  describe('Health API', () => {
+    describe('GET /health', () => {
+      it('should return health', (done) => {
+        request(app)
+          .get('/health')
+          .expect('Content-Type', /text/)
+          .expect(200, done);
+      });
+    });
+  });
+
+  describe('Rides API', () => {
+    const idsOfCreatedRides = [];
+
+    after((done) => {
+      db.run(`DELETE FROM Rides WHERE rideID IN (${idsOfCreatedRides.map(() => '?').join(',')})`, idsOfCreatedRides, done);
+    });
+
+    describe('POST /rides', () => {
+      const sampleRide = {
+        start_lat: -35,
+        start_long: 91,
+        end_lat: 21,
+        end_long: -107,
+        rider_name: 'Rider name',
+        driver_name: 'Driver name',
+        driver_vehicle: 'Driver vehicle',
+      };
+
+      const tryToCreateRideAndExpectCertainResponse = (ride, responseStatus, responseChecker) => {
+        return request(app)
+          .post('/rides')
+          .send(ride)
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .then((res) => {
+            const { body } = res;
+            responseChecker(body);
+          });
+      };
+
+      it('should create ride if correct data is passed', (done) => {
+        tryToCreateRideAndExpectCertainResponse(sampleRide, 200, (body) => {
+          expect(Array.isArray(body)).equal(true);
+          expect(body[0]).to.have.property('rideID').that.is.a('number');
+          expect(body[0].startLat).equal(sampleRide.start_lat);
+          expect(body[0].startLong).equal(sampleRide.start_long);
+          expect(body[0].endLat).equal(sampleRide.end_lat);
+          expect(body[0].endLong).equal(sampleRide.end_long);
+          expect(body[0].riderName).equal(sampleRide.rider_name);
+          expect(body[0].driverName).equal(sampleRide.driver_name);
+          expect(body[0].driverVehicle).equal(sampleRide.driver_vehicle);
+          expect(body[0]).to.have.property('created').that.is.a('string');
+
+          idsOfCreatedRides.push(body[0].rideID);
+        })
+          .then(() => done())
+          .catch((error) => done(error));
+      });
+
+      it('should throw validation error if "start_lat" is invalid', (done) => {
+        tryToCreateRideAndExpectCertainResponse({ ...sampleRide, start_lat: -91 }, 200, (body) => {
+          expect(body.error_code).equal('VALIDATION_ERROR');
+        })
+          .then(() => done())
+          .catch((error) => done(error));
+      });
+
+      it('should throw validation error if "start_long" is invalid', (done) => {
+        tryToCreateRideAndExpectCertainResponse(
+          { ...sampleRide, start_long: 180.1 },
+          200,
+          (body) => {
+            expect(body.error_code).equal('VALIDATION_ERROR');
+          },
+        )
+          .then(() => done())
+          .catch((error) => done(error));
+      });
+
+      it('should throw validation error if "end_lat" is invalid', (done) => {
+        tryToCreateRideAndExpectCertainResponse({ ...sampleRide, end_lat: 90.42 }, 200, (body) => {
+          expect(body.error_code).equal('VALIDATION_ERROR');
+        })
+          .then(() => done())
+          .catch((error) => done(error));
+      });
+
+      it('should throw validation error if "end_long" is invalid', (done) => {
+        tryToCreateRideAndExpectCertainResponse({ ...sampleRide, end_long: -1822 }, 200, (body) => {
+          expect(body.error_code).equal('VALIDATION_ERROR');
+        })
+          .then(() => done())
+          .catch((error) => done(error));
+      });
+
+      it('should throw validation error if "rider_name" is invalid', (done) => {
+        tryToCreateRideAndExpectCertainResponse({ ...sampleRide, rider_name: '' }, 200, (body) => {
+          expect(body.error_code).equal('VALIDATION_ERROR');
+        })
+          .then(() => done())
+          .catch((error) => done(error));
+      });
+
+      it('should throw validation error if "driver_name" is invalid', (done) => {
+        tryToCreateRideAndExpectCertainResponse({ ...sampleRide, driver_name: '' }, 200, (body) => {
+          expect(body.error_code).equal('VALIDATION_ERROR');
+        })
+          .then(() => done())
+          .catch((error) => done(error));
+      });
+
+      it('should throw validation error if "driver_vehicle" is invalid', (done) => {
+        tryToCreateRideAndExpectCertainResponse({ ...sampleRide, driver_vehicle: '' }, 200, (body) => {
+          expect(body.error_code).equal('VALIDATION_ERROR');
+        })
+          .then(() => done())
+          .catch((error) => done(error));
+      });
+    });
+
+    describe('GET /rides', () => {
+      it('should return list of rides', (done) => {
+        request(app)
+          .get('/rides')
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .then((res) => {
+            const { body } = res;
+
+            expect(Array.isArray(body)).equal(true);
+            expect(body.length).greaterThanOrEqual(1);
+            expect(body[0]).to.have.property('rideID').that.is.a('number');
+            expect(body[0]).to.have.property('startLat').that.is.a('number');
+            expect(body[0]).to.have.property('startLong').that.is.a('number');
+            expect(body[0]).to.have.property('endLat').that.is.a('number');
+            expect(body[0]).to.have.property('endLong').that.is.a('number');
+            expect(body[0]).to.have.property('riderName').that.is.a('string').with.length.greaterThanOrEqual(1);
+            expect(body[0]).to.have.property('driverName').that.is.a('string').with.length.greaterThanOrEqual(1);
+            expect(body[0]).to.have.property('driverVehicle').that.is.a('string').with.length.greaterThanOrEqual(1);
+            expect(body[0]).to.have.property('created').that.is.a('string');
+
+            return done();
+          })
+          .catch((error) => done(error));
+      });
+    });
+
+    describe('GET /rides/:id', () => {
+      it('should return ride if correct id is passed', (done) => {
+        request(app)
+          .get(`/rides/${idsOfCreatedRides[0]}`)
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .then((res) => {
+            const { body } = res;
+
+            expect(Array.isArray(body)).equal(true);
+            expect(body.length).equal(1);
+            expect(body[0]).to.have.property('rideID').that.is.a('number');
+            expect(body[0]).to.have.property('startLat').that.is.a('number');
+            expect(body[0]).to.have.property('startLong').that.is.a('number');
+            expect(body[0]).to.have.property('endLat').that.is.a('number');
+            expect(body[0]).to.have.property('endLong').that.is.a('number');
+            expect(body[0]).to.have.property('riderName').that.is.a('string').with.length.greaterThanOrEqual(1);
+            expect(body[0]).to.have.property('driverName').that.is.a('string').with.length.greaterThanOrEqual(1);
+            expect(body[0]).to.have.property('driverVehicle').that.is.a('string').with.length.greaterThanOrEqual(1);
+            expect(body[0]).to.have.property('created').that.is.a('string');
+
+            return done();
+          })
+          .catch((error) => done(error));
+      });
+
+      it('should throw not found error if invalid id is passed', (done) => {
+        request(app)
+          .get('/rides/invalid')
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .then((res) => {
+            const { body } = res;
+
+            expect(body.error_code).equal('RIDES_NOT_FOUND_ERROR');
+
+            return done();
+          })
+          .catch((error) => done(error));
+      });
     });
   });
 });


### PR DESCRIPTION
## Code changes

#### `package.json`
New dev-dependency (`chai`) has been added, it will be used in tests for assertions.
#### `package-lock.json`
New dependency version has been locked.
#### `.eslintrc.json`
Eslint rule "arrow-body-style" has been disabled, because it didn't really fit our code style.
#### `.nycrc.json`
`nyc` has been configured to enforce code coverage check (at least 80% for lines, branches and statements).
#### `tests/api.test.js`
New test cases have been created to increase tests code coverage.

## Tests
### POST /rides
#### should create ride if correct data is passed
New test have been created
#### should throw validation error if "start_lat" is invalid
New test have been created
#### should throw validation error if "start_long" is invalid
New test have been created
#### should throw validation error if "end_lat" is invalid
New test have been created
#### should throw validation error if "end_long" is invalid
New test have been created
#### should throw validation error if "rider_name" is invalid
New test have been created
#### should throw validation error if "driver_name" is invalid
New test have been created
#### should throw validation error if "driver_vehicle" is invalid
New test have been created
### GET /rides
#### should return list of rides
New test have been created
### GET /rides/:id
#### should return ride if correct id is passed
New test have been created
#### should throw not found error if invalid id is passed
New test have been created

## Documentation
`nyc` has been configured to enforce code coverage check (at least 80% for lines, branches and statements).
To increase tests code coverage - new test cases have been written.