### PR TITLE
Fix minor bug in `npm run test:load` command #load-testing #bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint --fix src/ tests/",
     "test": "nyc mocha tests/api",
-    "test:load": "npm run start:background && artillery run tests/load/rides.yaml && npm run stop:background",
+    "test:load": "npm run start:background && artillery run tests/load/rides.yaml ; npm run stop:background",
     "start": "node src/app.js",
     "start:background": "forever start src/app.js",
     "stop:background": "forever stop src/app.js"


### PR DESCRIPTION
## Code changes

#### `package.json`
Command `npm run test:load` is now always killing the daemon regardlessly of tests success/failure.

## Tests
No tests are required for this PR.

## Documentation
Command `npm run test:load` is now always killing the daemon regardlessly of tests success/failure. Before this change the command was only killing the daemon if tests succeeded.